### PR TITLE
What if the func take interface{} as parameter?

### DIFF
--- a/type-check.go
+++ b/type-check.go
@@ -209,8 +209,10 @@ func (tp typePair) unify(param, input reflect.Type) error {
 	}
 	if tyname := tyvarName(param); len(tyname) > 0 {
 		if cur, ok := tp.tyenv[tyname]; ok && cur != input {
-			return tp.error("Type variable %s expected type '%s' but got '%s'.",
-				tyname, cur, input)
+            if cur.Kind() != reflect.Interface {
+			    return tp.error("Type variable %s expected type '%s' but got '%s'.",
+				    tyname, cur, input)
+            }
 		} else if !ok {
 			tp.tyenv[tyname] = input
 		}


### PR DESCRIPTION
Hi BurntSushi,

Thank you very much for the lib first, it is awesome.
I am working on a project called GoPark, a local map/reduce data computing thing. At first I have to use interface{} a lot for the Mapper/Reducer function definitions, since I found ty project I have been working on refactoring and found a problem. 

Deep into the call stack, I cannot know the exact parameters type for a function, so I used the interface{} but only inside the lib, so there will be some functions like 

map(interface{}) int, and the input is a int, in ty.Check, that could be 
chk := ty.Check(new(func(func(ty.A) ty.B, ty.A) ty.B), fn, value)
so the first ty.A is interface{}, and the second ty.A is a int, cannot be unified.
I think it's reasonable that the function can take an interface{} input parameter, but the ty.Check check exactly the type matching. So I only added few lines of code to work around this. Is there any other problems that I didn't think through? 

Thank you very much.
